### PR TITLE
Create event package for client and consolidate events

### DIFF
--- a/src/main/java/org/protege/editor/owl/client/ClientSession.java
+++ b/src/main/java/org/protege/editor/owl/client/ClientSession.java
@@ -2,10 +2,12 @@ package org.protege.editor.owl.client;
 
 import edu.stanford.protege.metaproject.api.ProjectId;
 import org.protege.editor.owl.OWLEditorKit;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.api.Client;
-import org.protege.editor.owl.client.diff.ui.CommitOperationEvent;
-import org.protege.editor.owl.client.diff.ui.CommitOperationListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.CommitOperationEvent;
+import org.protege.editor.owl.client.event.CommitOperationListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.model.OWLEditorKitHook;
 import org.protege.editor.owl.model.event.EventType;
 import org.protege.editor.owl.model.event.OWLModelManagerChangeEvent;

--- a/src/main/java/org/protege/editor/owl/client/LocalHttpClient.java
+++ b/src/main/java/org/protege/editor/owl/client/LocalHttpClient.java
@@ -26,6 +26,8 @@ import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.UserInfo;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.protege.editor.owl.client.api.exception.LoginTimeoutException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.server.api.CommitBundle;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;

--- a/src/main/java/org/protege/editor/owl/client/action/CommitAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/CommitAction.java
@@ -1,11 +1,11 @@
 package org.protege.editor.owl.client.action;
 
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
-import org.protege.editor.owl.client.diff.ui.CommitOperationEvent;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.CommitOperationEvent;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.ui.RequestFocusListener;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.model.OWLModelManagerImpl;

--- a/src/main/java/org/protege/editor/owl/client/action/EnableAutoUpdateAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/EnableAutoUpdateAction.java
@@ -14,13 +14,13 @@ import java.util.concurrent.ScheduledFuture;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenuItem;
 
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.api.exception.SynchronizationException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.model.OWLModelManagerImpl;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.LocalHttpClient;
 import org.protege.editor.owl.server.versioning.ChangeHistoryUtils;
 import org.protege.editor.owl.server.versioning.CollectingChangeVisitor;

--- a/src/main/java/org/protege/editor/owl/client/action/LoginAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/LoginAction.java
@@ -9,9 +9,9 @@ import javax.swing.JMenuItem;
 
 import org.protege.editor.core.ProtegeManager;
 import org.protege.editor.core.ui.workspace.WorkspaceFrame;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
-import org.protege.editor.owl.client.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.ui.UserLoginPanel;
 
 /**

--- a/src/main/java/org/protege/editor/owl/client/action/LogoutAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/LogoutAction.java
@@ -2,10 +2,10 @@ package org.protege.editor.owl.client.action;
 
 import java.awt.event.ActionEvent;
 
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.api.Client;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.util.ClientUtils;
 
 /**

--- a/src/main/java/org/protege/editor/owl/client/action/ShowHistoryAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/ShowHistoryAction.java
@@ -12,11 +12,11 @@ import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.KeyStroke;
 
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.protege.editor.owl.client.api.exception.SynchronizationException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.ui.ChangeHistoryPanel;
 import org.protege.editor.owl.model.OWLWorkspace;
 import org.protege.editor.owl.server.versioning.api.VersionedOWLOntology;

--- a/src/main/java/org/protege/editor/owl/client/action/ShowStatusAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/ShowStatusAction.java
@@ -10,10 +10,10 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.LocalHttpClient;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.server.versioning.api.VersionedOWLOntology;
 

--- a/src/main/java/org/protege/editor/owl/client/action/ShowUncommittedChangesAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/ShowUncommittedChangesAction.java
@@ -16,10 +16,10 @@ import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
 import org.protege.editor.core.ui.util.JOptionPaneEx;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.api.exception.SynchronizationException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.ui.UncommittedChangesPanel;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.model.OWLWorkspace;

--- a/src/main/java/org/protege/editor/owl/client/action/UpdateAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/UpdateAction.java
@@ -12,11 +12,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.LocalHttpClient;
 import org.protege.editor.owl.client.api.exception.SynchronizationException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.model.OWLModelManagerImpl;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/JsonSerializationPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/JsonSerializationPanel.java
@@ -3,14 +3,14 @@ package org.protege.editor.owl.client.admin.ui;
 import org.protege.editor.core.Disposable;
 import org.protege.editor.core.ui.error.ErrorLogPanel;
 import org.protege.editor.owl.OWLEditorKit;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
 import org.protege.editor.owl.client.LocalHttpClient;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
 import org.protege.editor.owl.client.diff.ui.GuiUtils;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 
 import edu.stanford.protege.metaproject.api.ServerConfiguration;
 import edu.stanford.protege.metaproject.serialization.DefaultJsonSerializer;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/OperationPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/OperationPanel.java
@@ -10,13 +10,13 @@ import org.protege.editor.core.ui.list.MListSectionHeader;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 
 import javax.swing.*;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/PolicyPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/PolicyPanel.java
@@ -11,8 +11,6 @@ import org.protege.editor.core.ui.list.MListSectionHeader;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
@@ -21,6 +19,8 @@ import org.protege.editor.owl.client.admin.model.RoleMListItem;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.protege.editor.owl.client.diff.ui.GuiUtils;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 
 import javax.swing.*;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/ProjectPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/ProjectPanel.java
@@ -13,14 +13,14 @@ import org.protege.editor.core.ui.list.MListSectionHeader;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionChangeEvent.EventCategory;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
 import org.protege.editor.owl.client.admin.model.ProjectMListItem;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
+import org.protege.editor.owl.client.event.ClientSessionListener;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 
 import javax.swing.*;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/RolePanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/RolePanel.java
@@ -9,14 +9,14 @@ import org.protege.editor.core.ui.list.MListSectionHeader;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
 import org.protege.editor.owl.client.admin.model.RoleMListItem;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 
 import javax.swing.*;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/ServerSettingsPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/ServerSettingsPanel.java
@@ -9,14 +9,14 @@ import org.protege.editor.core.ui.list.MListSectionHeader;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.protege.editor.owl.client.diff.ui.GuiUtils;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 
 import javax.swing.*;

--- a/src/main/java/org/protege/editor/owl/client/admin/ui/UserPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/admin/ui/UserPanel.java
@@ -10,13 +10,13 @@ import org.protege.editor.core.ui.list.MListSectionHeader;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionChangeEvent;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.admin.AdminTabManager;
 import org.protege.editor.owl.client.admin.model.AdminTabEvent;
 import org.protege.editor.owl.client.admin.model.AdminTabListener;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
+import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 
 import javax.swing.*;

--- a/src/main/java/org/protege/editor/owl/client/diff/model/LogDiffManager.java
+++ b/src/main/java/org/protege/editor/owl/client/diff/model/LogDiffManager.java
@@ -6,7 +6,7 @@ import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.client.ClientSession;
 import org.protege.editor.owl.client.diff.DiffFactory;
 import org.protege.editor.owl.client.diff.DiffFactoryImpl;
-import org.protege.editor.owl.client.diff.ui.CommitOperationListener;
+import org.protege.editor.owl.client.event.CommitOperationListener;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.model.event.EventType;
 import org.protege.editor.owl.model.event.OWLModelManagerListener;

--- a/src/main/java/org/protege/editor/owl/client/diff/ui/ReviewButtonsPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/diff/ui/ReviewButtonsPanel.java
@@ -7,6 +7,7 @@ import org.protege.editor.owl.client.ClientSession;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.protege.editor.owl.client.diff.model.*;
+import org.protege.editor.owl.client.event.CommitOperationEvent;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.server.api.CommitBundle;
 import org.protege.editor.owl.server.api.exception.OWLServerException;

--- a/src/main/java/org/protege/editor/owl/client/event/ClientSessionChangeEvent.java
+++ b/src/main/java/org/protege/editor/owl/client/event/ClientSessionChangeEvent.java
@@ -1,4 +1,6 @@
-package org.protege.editor.owl.client;
+package org.protege.editor.owl.client.event;
+
+import org.protege.editor.owl.client.ClientSession;
 
 /**
  * @author Josef Hardi <johardi@stanford.edu> <br>

--- a/src/main/java/org/protege/editor/owl/client/event/ClientSessionListener.java
+++ b/src/main/java/org/protege/editor/owl/client/event/ClientSessionListener.java
@@ -1,4 +1,4 @@
-package org.protege.editor.owl.client;
+package org.protege.editor.owl.client.event;
 
 /**
  * @author Josef Hardi <johardi@stanford.edu> <br>

--- a/src/main/java/org/protege/editor/owl/client/event/CommitOperationEvent.java
+++ b/src/main/java/org/protege/editor/owl/client/event/CommitOperationEvent.java
@@ -1,4 +1,4 @@
-package org.protege.editor.owl.client.diff.ui;
+package org.protege.editor.owl.client.event;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/protege/editor/owl/client/event/CommitOperationListener.java
+++ b/src/main/java/org/protege/editor/owl/client/event/CommitOperationListener.java
@@ -1,4 +1,4 @@
-package org.protege.editor.owl.client.diff.ui;
+package org.protege.editor.owl.client.event;
 
 /**
  * @author Josef Hardi <johardi@stanford.edu> <br>

--- a/src/main/java/org/protege/editor/owl/client/util/ClientUtils.java
+++ b/src/main/java/org/protege/editor/owl/client/util/ClientUtils.java
@@ -7,8 +7,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.protege.editor.owl.client.ClientSession;
-import org.protege.editor.owl.client.ClientSessionListener;
 import org.protege.editor.owl.client.api.Client;
+import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.model.history.HistoryManager;
 import org.protege.editor.owl.server.versioning.ChangeHistoryUtils;
 import org.protege.editor.owl.server.versioning.Commit;


### PR DESCRIPTION
The `CommitOperationEvent` and `ClientSessionChangeEvent` are used by `EditTab` as well as the prompt diff ui. It seems logical to have an event package to consolidate these. This commit touches a lot of files so I'm pushing it as a PR in case anyone has a lot of changes locally. I can rebase it and push again if the latter obtains.
